### PR TITLE
fix:通过新的接口实现图片/视频保存至相册功能

### DIFF
--- a/harmony/camera_roll/src/main/ets/CameraRollParamTypes.ts
+++ b/harmony/camera_roll/src/main/ets/CameraRollParamTypes.ts
@@ -1,5 +1,3 @@
-import { expect } from '@ohos/hypium/src/main/interface';
-
 export type GetPhotosParams = {
   first: number;
   after?: string;

--- a/harmony/camera_roll/src/main/ets/CameraRollPermissionTurboModule.ts
+++ b/harmony/camera_roll/src/main/ets/CameraRollPermissionTurboModule.ts
@@ -48,7 +48,7 @@ const ASSET_TYPE_ALL = 'All'
 
 
 
-export class CameraRollTurboModule extends TurboModule {
+export class CameraRollPermissionTurboModule extends TurboModule {
   private phAccessHelper: photoAccessHelper.PhotoAccessHelper
 
   constructor(ctx: TurboModuleContext) {


### PR DESCRIPTION
# Summary
Closes #9 
通过新的接口实现图片/视频保存至相册功能

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
