### PR TITLE
fix:修复使用save方法后有两次图库访问记录问题

### DIFF
--- a/harmony/camera_roll/src/main/ets/CameraRollTurboModule.ts
+++ b/harmony/camera_roll/src/main/ets/CameraRollTurboModule.ts
@@ -78,7 +78,7 @@ export class CameraRollTurboModule extends TurboModule implements TM.RNCCameraRo
       let file = fs.openSync(saveUri, fs.OpenMode.READ_ONLY);
       let buffer = new ArrayBuffer(stat.size);
       fs.readSync(file.fd, buffer);
-      let media_file = fs.openSync(saveUris[0], fs.OpenMode.READ_WRITE);
+      let media_file = fs.openSync(saveUris[0], fs.OpenMode.WRITE_ONLY);
       fs.writeSync(media_file.fd, buffer);
       fs.closeSync(file);
       if (resourceType) {


### PR DESCRIPTION
# Summary

修复使用save方法后有两次图库访问记录问题

## Test Plan

## Checklist

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
