### PR TITLE
修复Codegen过程接口返回值类型识别错误

### DIFF
--- a/src/NativeCameraRollModule.ts
+++ b/src/NativeCameraRollModule.ts
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-types */
 // we use Object type because methods on the native side use NSDictionary and ReadableMap
 // and we want to stay compatible with those
-import {TurboModuleRegistry, TurboModule} from 'react-native';
-import type {PhotoThumbnail} from './CameraRoll';
-import type {Double} from 'react-native/Libraries/Types/CodegenTypes';
+import { TurboModuleRegistry, TurboModule } from 'react-native';
+import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
+
+export type PhotoThumbnail = {
+  thumbnailBase64: string;
+};
 
 export type AlbumType = 'All' | 'Album' | 'SmartAlbum';
 


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

import type {PhotoThumbnail} from './CameraRoll';
getPhotoThumbnail(
internalID: string,
options: Object,
): Promise;
经过Codegen生成后；PhotoThumbnail会识别失败导致函数变为getPhotoThumbnail( internalID: string, options: Object): Promise;导致编译失败。

## Test Plan

无

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [√ ] 已经在真机设备或模拟器上测试通过
- [√ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
